### PR TITLE
Adding secondarygroup to AddFirewallAction + implement negateSource

### DIFF
--- a/api/securitypolicy/securitypolicy_types.go
+++ b/api/securitypolicy/securitypolicy_types.go
@@ -53,6 +53,7 @@ type Action struct {
 	Direction              string          `xml:"direction"`
 	IsEnabled              bool            `xml:"isEnabled,omitempty"`
 	SecondarySecurityGroup []SecurityGroup `xml:"secondarySecurityGroup,omitempty"`
+	NegateSource           bool            `xml:"outsideSecondaryContainer,omitempty"`
 	Applications           *Applications   `xml:"applications,omitempty"`
 }
 


### PR DESCRIPTION
When creating a firewall rule, it's possible to put the secondarygroup as a source or as a destination. Here having 2 different methods with only one authorizing it was limiting.
In addition, I added the "reject" action which is available in the API and which is different as "block".